### PR TITLE
feat: ✨ Enhance logging and command handling in pull-watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Guards your watch, your time, avoids wasting it, get it? No? Never mind. I am ju
 - 🕒 Configurable poll interval (because sometimes you need a coffee break)
 - 🎯 Graceful process management (no rough handling here!)
 - 📁 Support for different git directories (home is where your .git is)
-- 📢 Verbose logging option (for when you're feeling chatty)
+- 📢 Smart logging levels (quiet, normal, and verbose - you choose how chatty it gets!)
 - 🛡️ Proper signal handling (catches signals like a pro)
 - ⏱️ Context-aware git operations with timeouts (patience is a virtue, but timeouts are better)
 - 🔄 Run on start option (for the eager beavers)
@@ -59,13 +59,13 @@ choco install pull-watch
 ## 🎮 Usage
 
 ```
-  
+
   Usage: pull-watch [options] -- <command>
-  
+
    Watch git repository for remote changes and run commands.
-  
+
    It's like: 'git pull && <command>' but with polling and automatic process management.
-  
+
   Options:
     -git-dir string
       	Git repository directory (default ".")
@@ -73,6 +73,8 @@ choco install pull-watch
       	Try graceful stop before force kill
     -interval duration
       	Poll interval (e.g. 15s, 1m) (default 15s)
+    -quiet
+      	Show only errors and warnings
     -run-on-start
       	Run command on startup regardless of git state
     -stop-timeout duration
@@ -81,7 +83,7 @@ choco install pull-watch
       	Show timestamps in logs
     -verbose
       	Enable verbose logging
-  
+
 ```
 ## 🌟 Examples
 
@@ -107,6 +109,18 @@ pull-watch -- node server.js
 For the gentler souls among us
 ```bash
 pull-watch -graceful -stop-timeout 10s -- ./my-server
+```
+
+### Watch with different logging levels:
+```bash
+# Default mode - shows important info
+pull-watch -- npm start
+
+# Quiet mode - shows only errors and warnings
+pull-watch -quiet -- npm start
+
+# Verbose mode - shows all the details
+pull-watch -verbose -- npm start
 ```
 
 ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	PollInterval  time.Duration
 	Command       []string
 	GitDir        string
-	Verbose       bool
+	LogLevel      logger.LogLevel
 	GracefulStop  bool
 	StopTimeout   time.Duration
 	Logger        *logger.Logger

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -32,12 +32,10 @@ func (e *DefaultExecutor) ExecuteCommand(ctx context.Context, name string, args 
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = e.cfg.GitDir
 
-	if e.cfg.Verbose {
-		e.cfg.Logger.MultiColor(
-			logger.InfoSegment("Executing command: "),
-			logger.HighlightSegment(fmt.Sprintf("%s %s", name, strings.Join(args, " "))),
-		)
-	}
+	e.cfg.Logger.MultiColor(logger.VerboseLevel,
+		logger.InfoSegment("Executing command: "),
+		logger.HighlightSegment(fmt.Sprintf("%s %s", name, strings.Join(args, " "))),
+	)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/git/compare.go
+++ b/internal/git/compare.go
@@ -63,16 +63,14 @@ func (r *GitRepository) compareCommits(ctx context.Context, commitA, commitB str
 // HandleCommitComparison handles the commit comparison and decides whether to pull changes
 func (repo *GitRepository) HandleCommitComparison(ctx context.Context, localCommit, remoteCommit string) (CommitComparisonResult, error) {
 	// Log commits if verbose
-	if repo.cfg.Verbose {
-		repo.cfg.Logger.MultiColor(
-			logger.InfoSegment("Local commit: "),
-			logger.HighlightSegment(localCommit),
-		)
-		repo.cfg.Logger.MultiColor(
-			logger.InfoSegment("Remote commit: "),
-			logger.HighlightSegment(remoteCommit),
-		)
-	}
+	repo.cfg.Logger.MultiColor(logger.VerboseLevel,
+		logger.InfoSegment("Local commit: "),
+		logger.HighlightSegment(localCommit),
+	)
+	repo.cfg.Logger.MultiColor(logger.VerboseLevel,
+		logger.InfoSegment("Remote commit: "),
+		logger.HighlightSegment(remoteCommit),
+	)
 
 	// Compare commits
 	comparison, err := repo.compareCommits(ctx, localCommit, remoteCommit)
@@ -83,50 +81,44 @@ func (repo *GitRepository) HandleCommitComparison(ctx context.Context, localComm
 	// Handle different comparison results
 	switch comparison {
 	case AIsAncestorOfB:
-		if repo.cfg.Verbose {
-			repo.cfg.Logger.MultiColor(
-				logger.InfoSegment("Local commit is "),
-				logger.HighlightSegment("behind"),
-				logger.InfoSegment(" remote commit, "),
-				logger.HighlightSegment("pulling changes..."),
-			)
-		}
+		repo.cfg.Logger.MultiColor(logger.DefaultLevel,
+			logger.InfoSegment("Local commit is "),
+			logger.HighlightSegment("behind"),
+			logger.InfoSegment(" remote commit, "),
+			logger.HighlightSegment("pulling changes..."),
+		)
+
 		if _, err := repo.Pull(ctx); err != nil {
 			return UnknownCommitComparisonResult, fmt.Errorf("failed to pull changes: %w", err)
 		}
 		return AIsAncestorOfB, nil
 
 	case BIsAncestorOfA:
-		if repo.cfg.Verbose {
-			repo.cfg.Logger.MultiColor(
-				logger.InfoSegment("Local commit is "),
-				logger.HighlightSegment("ahead"),
-				logger.InfoSegment(" of remote commit, "),
-				logger.HighlightSegment("not pulling."),
-			)
-		}
+		repo.cfg.Logger.MultiColor(logger.VerboseLevel,
+			logger.InfoSegment("Local commit is "),
+			logger.HighlightSegment("ahead"),
+			logger.InfoSegment(" of remote commit, "),
+			logger.HighlightSegment("not pulling."),
+		)
 		return BIsAncestorOfA, nil
 
 	case CommitsDiverged:
-		if repo.cfg.Verbose {
-			repo.cfg.Logger.MultiColor(
-				logger.InfoSegment("Local commit and remote commit "),
-				logger.HighlightSegment("have diverged"),
-				logger.InfoSegment(": "),
-				logger.HighlightSegment("not pulling."),
-			)
-		}
+		repo.cfg.Logger.MultiColor(logger.VerboseLevel,
+			logger.InfoSegment("Local commit and remote commit "),
+			logger.HighlightSegment("have diverged"),
+			logger.InfoSegment(": "),
+			logger.HighlightSegment("not pulling."),
+		)
 		return CommitsDiverged, nil
 
 	case CommitsEqual:
-		if repo.cfg.Verbose {
-			repo.cfg.Logger.MultiColor(
-				logger.InfoSegment("Local commit and remote commit "),
-				logger.HighlightSegment("are the same"),
-				logger.InfoSegment(": "),
-				logger.HighlightSegment("not pulling."),
-			)
-		}
+		repo.cfg.Logger.MultiColor(logger.VerboseLevel,
+			logger.InfoSegment("Local commit and remote commit "),
+			logger.HighlightSegment("are the same"),
+			logger.InfoSegment(": "),
+			logger.HighlightSegment("not pulling."),
+		)
+
 		return CommitsEqual, nil
 
 	default:

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -8,16 +8,26 @@ import (
 	"github.com/fatih/color"
 )
 
+type LogLevel int
+
+const (
+	QuietLevel LogLevel = iota
+	DefaultLevel
+	VerboseLevel
+)
+
 var (
 	prefix         = color.New(color.FgCyan).Sprint("[pull-watch] ")
 	errorColor     = color.New(color.FgRed).SprintFunc()
 	infoColor      = color.New(color.FgGreen).SprintFunc()
 	highlightColor = color.New(color.FgHiYellow).Add(color.Bold).SprintFunc()
+	warnColor      = color.New(color.FgYellow).SprintFunc()
 )
 
 // Logger wraps the standard logger with custom formatting
 type Logger struct {
 	*log.Logger
+	level LogLevel
 }
 
 // Option is a functional option for configuring the logger
@@ -30,10 +40,18 @@ func WithTimestamp() Option {
 	}
 }
 
+// WithLogLevel sets the logging level
+func WithLogLevel(level LogLevel) Option {
+	return func(l *Logger) {
+		l.level = level
+	}
+}
+
 // New creates a new Logger instance with the given options
 func New(opts ...Option) *Logger {
 	l := &Logger{
 		Logger: log.New(os.Stderr, prefix, 0),
+		level:  DefaultLevel, // Set default level
 	}
 	for _, opt := range opts {
 		opt(l)
@@ -41,23 +59,43 @@ func New(opts ...Option) *Logger {
 	return l
 }
 
+// Warn logs a warning message with yellow color
+func (l *Logger) Warn(format string, v ...interface{}) {
+	if l.level >= QuietLevel {
+		l.Printf(warnColor("WARNING: "+format), v...)
+	}
+}
+
 // Error logs an error message with red color
 func (l *Logger) Error(format string, v ...interface{}) {
-	l.Printf(errorColor("ERROR: "+format), v...)
+	if l.level >= QuietLevel {
+		l.Printf(errorColor("ERROR: "+format), v...)
+	}
 }
 
 // Info logs an info message with green color
 func (l *Logger) Info(format string, v ...interface{}) {
-	l.Printf(infoColor(format), v...)
+	if l.level >= DefaultLevel {
+		l.Printf(infoColor(format), v...)
+	}
+}
+
+// Debug logs a debug message (only in verbose mode)
+func (l *Logger) Debug(format string, v ...interface{}) {
+	if l.level >= VerboseLevel {
+		l.Printf(format, v...)
+	}
 }
 
 // MultiColor logs a message with multiple color segments
-func (l *Logger) MultiColor(segments ...ColoredSegment) {
-	var parts []string
-	for _, seg := range segments {
-		parts = append(parts, seg.Color(seg.Text))
+func (l *Logger) MultiColor(level LogLevel, segments ...ColoredSegment) {
+	if l.level >= level {
+		var parts []string
+		for _, seg := range segments {
+			parts = append(parts, seg.Color(seg.Text))
+		}
+		l.Println(strings.Join(parts, ""))
 	}
-	l.Println(strings.Join(parts, ""))
 }
 
 // ColoredSegment represents a text segment with its color

--- a/internal/runner/process_manager.go
+++ b/internal/runner/process_manager.go
@@ -60,8 +60,8 @@ func (pm *ProcessManager) Start() error {
 
 	// Make sure any previous process is fully cleaned up
 	if pm.cmd != nil {
-		if err := pm.forceStop(); err != nil && pm.cfg.Verbose {
-			pm.logger.MultiColor(
+		if err := pm.forceStop(); err != nil {
+			pm.logger.MultiColor(logger.QuietLevel,
 				logger.ErrorSegment("Failed to clean up previous process: "),
 				logger.HighlightSegment(fmt.Sprintf("%v", err)),
 			)

--- a/scripts/update_usage.sh
+++ b/scripts/update_usage.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Get the help output
-HELP_OUTPUT=$(go run ./cmd/pull-watch -h | sed 's/^/  /')
+HELP_OUTPUT=$(go run . -h | sed 's/^/  /')
 
 # Create temp file
 tmp=$(mktemp)


### PR DESCRIPTION
- Introduced a new `quiet` flag to control logging verbosity, allowing users to suppress non-error messages.
- Updated the `MainCommand` structure to accommodate the new `quiet` flag and adjusted logging levels accordingly.
- Refactored logging calls across the application to utilize the new logging levels, improving clarity and consistency in log outputs.
- Enhanced the `Config` struct to replace the `Verbose` boolean with a `LogLevel` type for more granular control over logging behavior.
- Improved error handling and logging in various components, ensuring that relevant information is logged based on the current logging level.

These changes enhance the usability and maintainability of the pull-watch application by providing better control over logging and clearer output during command execution.

Signed-off-by: Alessandro De Blasis <alex@deblasis.net>