### PR TITLE
fix: 🐛 Update version output in VersionCommand to include build information

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -173,7 +174,11 @@ type VersionCommand struct {
 }
 
 func (c *VersionCommand) Run(_ []string) int {
-	c.ui.Output(fmt.Sprintf("pull-watch version %s", c.Version))
+	if info, ok := debug.ReadBuildInfo(); ok {
+		version = info.Main.Version
+	}
+
+	c.ui.Output(fmt.Sprintf("pull-watch version (%s) %s", c.Version, version))
 	return 0
 }
 


### PR DESCRIPTION
- Enhanced the `Run` method in `VersionCommand` to retrieve and display the build version using `debug.ReadBuildInfo()`.
- Updated the output format to include both the predefined version and the build version, improving clarity for users.

These changes provide better visibility into the versioning of the pull-watch application, aiding in debugging and user awareness.

Signed-off-by: Alessandro De Blasis <alex@deblasis.net>