### PR TITLE
feat: npm package

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,11 +3,12 @@ name: goreleaser
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   goreleaser:
@@ -21,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: "1.21"
 
       - name: Set up UPX
         uses: crazy-max/ghaction-upx@v3
@@ -46,3 +47,20 @@ jobs:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
           WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install Node.js dependencies for publish script
+        run: npm install
+
+      - name: Publish to npm using custom script
+        if: startsWith(github.ref, 'refs/tags/')
+        run: node scripts/publish-npm.js
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
+          GITHUB_REF: ${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 .choco/
 bin/*
+node_modules/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+const path = require("path");
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+
+// Determine the expected path to the actual binary relative to this script
+const binaryDir = path.join(__dirname, "bin");
+const binaryName =
+  process.platform === "win32" ? "pull-watch.exe" : "pull-watch";
+const binaryPath = path.join(binaryDir, binaryName);
+
+// Check if the binary exists (postinstall should have run)
+if (!fs.existsSync(binaryPath)) {
+  console.error(`[pull-watch] Error: Binary not found at ${binaryPath}`);
+  console.error(
+    "[pull-watch] Postinstall script might have failed. Try reinstalling the package."
+  );
+  // Attempt to run postinstall manually? Risky, might not have perms or deps.
+  // Or suggest a specific reinstall command.
+  process.exit(1);
+}
+
+// Spawn the actual binary, passing all arguments (slice(2) removes 'node' and 'cli.js')
+// Use spawnSync for simplicity as CLI tools are often synchronous
+const result = spawnSync(binaryPath, process.argv.slice(2), {
+  stdio: "inherit", // Pass stdin, stdout, stderr directly through
+});
+
+// Exit with the same code as the binary process if it returns one
+if (result.error) {
+  console.error(
+    `[pull-watch] Error spawning binary ${binaryPath}: ${result.error}`
+  );
+  process.exit(1); // Exit with failure
+}
+
+process.exit(result.status === null ? 0 : result.status); // Exit with binary's exit code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,120 @@
+{
+  "name": "@ship-digital/pull-watch",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@ship-digital/pull-watch",
+      "version": "0.0.0",
+      "license": "MIT",
+      "bin": {
+        "pull-watch": "bin/pull-watch"
+      },
+      "devDependencies": {
+        "adm-zip": "^0.5.16",
+        "tar": "^7.4.3"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@ship-digital/pull-watch",
+  "version": "0.0.0",
+  "description": "A tool that watches a git repository for changes and runs a specified command",
+  "license": "MIT",
+  "homepage": "https://github.com/ship-digital/pull-watch",
+  "author": {
+    "name": "Alessandro De Blasis",
+    "email": "alex@deblasis.net"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ship-digital/pull-watch.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ship-digital/pull-watch/issues"
+  },
+  "keywords": [
+    "git",
+    "pull",
+    "watch",
+    "monitor",
+    "automation",
+    "golang",
+    "cli"
+  ],
+  "bin": {
+    "pull-watch": "cli.js"
+  },
+  "files": [
+    "bin",
+    "README.md",
+    "LICENSE",
+    "postinstall.js",
+    "cli.js"
+  ],
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  },
+  "dependencies": {
+    "adm-zip": "^0.5.10",
+    "tar": "^6.2.1",
+    "axios": "^1.6.8"
+  }
+}

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,190 @@
+// postinstall.js
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const tar = require("tar");
+const AdmZip = require("adm-zip");
+const axios = require("axios");
+
+const GITHUB_REPO_OWNER = "ship-digital";
+const GITHUB_REPO_NAME = "pull-watch";
+const PKG_BIN_DIR_NAME = "bin"; // Matches 'files' and 'bin' in package.json
+
+// --- Helper Functions ---
+
+function log(message) {
+  console.log(`[pull-watch-postinstall] ${message}`);
+}
+
+function error(message) {
+  console.error(`[pull-watch-postinstall] ERROR: ${message}`);
+  process.exit(1);
+}
+
+function getNodeOs() {
+  const platform = os.platform();
+  switch (platform) {
+    case "linux":
+      return "Linux";
+    case "darwin":
+      return "Darwin";
+    case "win32":
+      return "Windows";
+    default:
+      return null; // Or map to Go equivalents if needed
+  }
+}
+
+function getNodeArch() {
+  const arch = os.arch();
+  switch (arch) {
+    case "x64":
+      return "x86_64";
+    case "arm64":
+      return "arm64";
+    // Add other mappings if needed (ia32 -> i386?)
+    default:
+      return null;
+  }
+}
+
+function getGoReleaserAssetName(version, nodeOs, nodeArch) {
+  // Construct asset name based on goreleaser's default archive.name_template
+  // Example: pull-watch_Linux_x86_64.tar.gz
+  // Example: pull-watch_Windows_x86_64.zip
+  // Adjust this logic EXACTLY match your .goreleaser.yaml `archives.name_template` output!
+  const baseName = GITHUB_REPO_NAME; // Assumes project name matches repo name
+  const ext = nodeOs === "Windows" ? "zip" : "tar.gz";
+  return `${baseName}_${nodeOs}_${nodeArch}.${ext}`;
+}
+
+function getBinaryName(targetOs) {
+  // Get the binary name from the parent package.json's 'bin' field
+  try {
+    const parentPackageJsonPath = path.resolve(__dirname, "package.json");
+    const parentPackageJson = JSON.parse(
+      fs.readFileSync(parentPackageJsonPath, "utf8")
+    );
+    const binKey = Object.keys(parentPackageJson.bin)[0];
+    return targetOs === "Windows" ? `${binKey}.exe` : binKey;
+  } catch (e) {
+    error(
+      `Failed to read or parse package.json to determine binary name: ${e}`
+    );
+    return targetOs === "Windows" ? "pull-watch.exe" : "pull-watch"; // Fallback
+  }
+}
+
+// --- Main Postinstall Logic ---
+
+async function main() {
+  log("Starting postinstall script...");
+
+  // 1. Determine Platform and Version
+  const nodeOs = getNodeOs();
+  const nodeArch = getNodeArch();
+  let version;
+  try {
+    version = require("./package.json").version; // Read version from own package.json
+  } catch (e) {
+    error(`Failed to read version from package.json: ${e}`);
+  }
+
+  if (!nodeOs || !nodeArch) {
+    error(
+      `Unsupported platform or architecture: ${os.platform()}/${os.arch()}. Cannot download binary.`
+    );
+  }
+  log(`Detected platform: ${nodeOs} ${nodeArch}`);
+  log(`Required version: ${version}`);
+
+  // 2. Construct Download URL
+  const assetName = getGoReleaserAssetName(version, nodeOs, nodeArch);
+  const downloadUrl = `https://github.com/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/releases/download/v${version}/${assetName}`;
+  log(`Attempting to download binary package from: ${downloadUrl}`);
+
+  // 3. Download the Archive
+  let response;
+  try {
+    response = await axios({
+      url: downloadUrl,
+      method: "GET",
+      responseType: "arraybuffer", // Important for binary data
+      headers: {
+        Accept: "application/octet-stream",
+      },
+    });
+    log(`Successfully downloaded ${assetName}`);
+  } catch (err) {
+    if (err.response) {
+      error(
+        `Failed to download binary. Status: ${err.response.status}. URL: ${downloadUrl}. Error: ${err.message}`
+      );
+    } else {
+      error(
+        `Failed to download binary. URL: ${downloadUrl}. Error: ${err.message}`
+      );
+    }
+  }
+
+  // 4. Prepare Extraction Target
+  const targetDir = path.resolve(__dirname); // Install into the package's root directory
+  const binDir = path.join(targetDir, PKG_BIN_DIR_NAME);
+  const binaryName = getBinaryName(nodeOs);
+  const binaryPath = path.join(binDir, binaryName);
+
+  log(`Ensuring target directory exists: ${binDir}`);
+  fs.mkdirSync(binDir, { recursive: true });
+
+  // 5. Extract the Binary
+  try {
+    log(`Extracting ${binaryName} from downloaded archive...`);
+    if (assetName.endsWith(".tar.gz")) {
+      // Use tar's stream capability
+      await new Promise((resolve, reject) => {
+        const extractor = tar.x({
+          cwd: binDir,
+          // Only extract the binary file, assumes it's at the root of the tarball
+          filter: (p) => p === binaryName,
+          strip: 0,
+          onentry: (entry) => {
+            entry.path = binaryName;
+          }, // Ensure correct final name
+        });
+        extractor.on("error", reject);
+        extractor.on("finish", resolve);
+        // Create a readable stream from the buffer and pipe it
+        const Readable = require("stream").Readable;
+        const bufferStream = new Readable();
+        bufferStream.push(response.data);
+        bufferStream.push(null); // Signal end of stream
+        bufferStream.pipe(extractor);
+      });
+    } else if (assetName.endsWith(".zip")) {
+      const zip = new AdmZip(response.data);
+      // Assumes binary is at the root of the zip
+      zip.extractEntryTo(binaryName, binDir, false, true);
+    } else {
+      error(`Unsupported archive format: ${assetName}`);
+    }
+
+    if (!fs.existsSync(binaryPath)) {
+      error(`Binary not found after extraction: ${binaryPath}`);
+    }
+
+    log(`Successfully extracted binary to: ${binaryPath}`);
+
+    // 6. Make Binary Executable (non-Windows)
+    if (nodeOs !== "Windows") {
+      log(`Setting executable permission for ${binaryPath}`);
+      fs.chmodSync(binaryPath, 0o755);
+    }
+  } catch (e) {
+    error(`Failed to extract binary from archive: ${e}`);
+  }
+
+  log("Postinstall script completed successfully.");
+}
+
+// --- Run ---
+main();

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -1,0 +1,151 @@
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+// --- Configuration ---
+const GORELEASER_DIST = path.resolve(process.cwd(), "dist");
+const TEMPLATE_PACKAGE_JSON = path.resolve(process.cwd(), "package.json");
+const NPM_BUILD_DIR = path.resolve(GORELEASER_DIST, "npm-postinstall-build"); // Dir to store final .tgz file
+const TEMP_WORK_DIR = path.resolve(
+  GORELEASER_DIST,
+  "npm-postinstall-temp-work"
+); // Dir for temporary package building
+const GITHUB_REF = process.env.GITHUB_REF; // e.g., refs/tags/v1.2.3
+const NPM_TOKEN = process.env.NODE_AUTH_TOKEN;
+const NPM_PROVENANCE = process.env.NPM_CONFIG_PROVENANCE === "true";
+// --- End Configuration ---
+
+// --- Helper Functions ---
+
+function log(message) {
+  console.log(`[publish-npm] ${message}`);
+}
+
+function error(message) {
+  console.error(`[publish-npm] ERROR: ${message}`);
+  process.exit(1);
+}
+
+function getVersionFromTag(ref) {
+  if (!ref || !ref.startsWith("refs/tags/v")) {
+    error(
+      `Invalid or missing GITHUB_REF tag: ${ref}. Must start with 'refs/tags/v'.`
+    );
+  }
+  return ref.substring("refs/tags/v".length);
+}
+
+function runCommand(command, cwd) {
+  log(`Running: ${command} in ${cwd || "current dir"}`);
+  try {
+    const output = execSync(command, { stdio: "inherit", cwd }); // Show output
+    return output;
+  } catch (e) {
+    error(`Command failed: ${command}\n${e}`);
+  }
+}
+
+// --- Main Script ---
+
+function main() {
+  log("Starting simplified npm publish script (postinstall method)...");
+
+  if (!NPM_TOKEN) {
+    error("NODE_AUTH_TOKEN environment variable is not set.");
+  }
+
+  // 1. Read Inputs
+  if (!fs.existsSync(TEMPLATE_PACKAGE_JSON)) {
+    error(`Template package.json file not found: ${TEMPLATE_PACKAGE_JSON}`);
+  }
+
+  const templatePackageJson = JSON.parse(
+    fs.readFileSync(TEMPLATE_PACKAGE_JSON, "utf8")
+  );
+  const version = getVersionFromTag(GITHUB_REF);
+  const mainPackageName = templatePackageJson.name;
+
+  log(`Publishing version: ${version}`);
+  log(`Package name: ${mainPackageName}`);
+
+  // 2. Prepare Directories
+  fs.rmSync(NPM_BUILD_DIR, { recursive: true, force: true });
+  fs.rmSync(TEMP_WORK_DIR, { recursive: true, force: true });
+  fs.mkdirSync(NPM_BUILD_DIR, { recursive: true });
+  fs.mkdirSync(TEMP_WORK_DIR, { recursive: true });
+
+  // 3. Build Main Package
+  log("Building the main package...");
+  const mainPackageTempDir = path.join(TEMP_WORK_DIR, "main-package");
+  fs.mkdirSync(mainPackageTempDir, { recursive: true });
+
+  // Prepare main package.json
+  const finalMainPackageJson = { ...templatePackageJson }; // Copy template
+  finalMainPackageJson.version = version; // Set correct version
+  // Remove devDependencies before packing
+  delete finalMainPackageJson.devDependencies;
+  // Ensure no optionalDependencies are lingering (should be removed from template already)
+  delete finalMainPackageJson.optionalDependencies;
+
+  fs.writeFileSync(
+    path.join(mainPackageTempDir, "package.json"),
+    JSON.stringify(finalMainPackageJson, null, 2)
+  );
+
+  // Copy essential files defined in template's 'files'
+  if (templatePackageJson.files) {
+    templatePackageJson.files.forEach((f) => {
+      const sourcePath = path.resolve(process.cwd(), f);
+      const destPath = path.join(mainPackageTempDir, path.basename(f)); // Place in root of package
+      if (fs.existsSync(sourcePath)) {
+        const stats = fs.statSync(sourcePath);
+        if (stats.isFile()) {
+          fs.copyFileSync(sourcePath, destPath);
+          log(`Copied file to main package: ${f}`);
+        } else {
+          log(`Skipping non-file entry from 'files': ${f}`); // Don't copy 'bin' dir etc.
+        }
+      } else {
+        log(
+          `WARN: File specified in template 'files' not found: ${sourcePath}`
+        );
+      }
+    });
+  } else {
+    error(
+      "Template package.json 'files' array is missing or empty. Cannot determine files to include."
+    );
+  }
+
+  // 4. Pack the main package
+  runCommand("npm pack", mainPackageTempDir);
+  // npm pack converts `@scope/pkg` to `scope-pkg-version.tgz`
+  const mainTgzName = `${mainPackageName
+    .replace("@", "")
+    .replace("/", "-")}-${version}.tgz`;
+  const mainPackedTgzPath = path.join(mainPackageTempDir, mainTgzName);
+  const mainFinalTgzPath = path.join(NPM_BUILD_DIR, mainTgzName);
+
+  if (!fs.existsSync(mainPackedTgzPath)) {
+    error(`Packed main tgz not found after 'npm pack': ${mainPackedTgzPath}`);
+  }
+  fs.renameSync(mainPackedTgzPath, mainFinalTgzPath); // Move to final build dir
+  log(`Packed main package: ${mainFinalTgzPath}`);
+
+  // 5. Publish the main package
+  log(`Publishing package to npm...`);
+  const publishCmdBase = `npm publish --access public`;
+  const publishCmdProvenance = NPM_PROVENANCE ? "--provenance" : "";
+
+  runCommand(`${publishCmdBase} "${mainFinalTgzPath}" ${publishCmdProvenance}`);
+  log(`Published: ${path.basename(mainFinalTgzPath)}`);
+
+  // 6. Cleanup
+  log("Cleaning up temporary directories...");
+  fs.rmSync(TEMP_WORK_DIR, { recursive: true, force: true });
+
+  log("Simplified npm publish script finished successfully!");
+}
+
+// --- Execute ---
+main();


### PR DESCRIPTION
- Added `cli.js` to serve as the entry point for the pull-watch command, handling binary execution and error management.
- Introduced `postinstall.js` for downloading and extracting the necessary binary based on the user's OS and architecture.
- Created `package.json` and `package-lock.json` to manage dependencies and project metadata.
- Updated `.gitignore` to include `node_modules/` and added `.npmrc` for npm authentication.
- Enhanced GitHub Actions workflow to set up Node.js and install dependencies for the publish script.

Signed-off-by: Alessandro De Blasis <alex@deblasis.net>