### PR TITLE
fix: specify shell for tag determination step in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,6 +72,7 @@ jobs:
       # Determine the tag to use for GoReleaser
       - name: Determine Target Tag for GoReleaser
         id: determine_tag
+        shell: bash
         run: |
           TARGET_TAG=""
           if [[ "${{ needs.release-please.outputs.release_created }}" == "true" && -n "${{ needs.release-please.outputs.tag_name }}" ]]; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,12 +45,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # GoReleaser needs the full history
-
-      # Fetch the tag created by release-please if this wasn't a manual trigger
-      # On manual trigger, assume the tag exists
-      - name: Fetch Tag
-        if: ${{ needs.release-please.outputs.release_created }}
-        run: git fetch --tags origin ${{ needs.release-please.outputs.tag_name }}
+          fetch-tags: true # Fetch tags too
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
- Added `shell: bash` to the "Determine Target Tag for GoReleaser" step in the `release-please.yml` workflow to ensure proper execution of the script.

Signed-off-by: Alessandro De Blasis <alex@deblasis.net>