### PR TITLE
fix(publish-npm): add RELEASE_TAG support for version determination

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -201,7 +201,7 @@ jobs:
           set -eo pipefail
           retries=5
           delay=15
-          branch_name="pull-watch-${TARGET_TAG}"
+          branch_name="pull-watch-${APP_VERSION_NO_V}"
           manifest_path="manifests/s/${WINGET_PUBLISHER}/${WINGET_PACKAGE}/${APP_VERSION_NO_V}/${WINGET_PUBLISHER}.${WINGET_PACKAGE}.installer.yaml"
           repo_url="https://github.com/${WINGET_REPO_OWNER}/${WINGET_REPO_NAME}.git"
 
@@ -365,7 +365,7 @@ jobs:
           COMMIT_MSG="ci(winget): update manifests for ${TAG_NAME}"
           git commit -m "$COMMIT_MSG" -m "$SIGNOFF_LINE"
 
-          BRANCH_NAME="pull-watch-${TAG_NAME}"
+          BRANCH_NAME="pull-watch-${APP_VERSION_NO_V}"
           echo "Pushing manifest updates commit to branch ${BRANCH_NAME} in ${WINGET_REPO_OWNER}/${WINGET_REPO_NAME}..."
           # Use the GITHUB_TOKEN provided by the workflow runner for authentication
           # Ensure the token has permissions to write to the fork.

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -11,6 +11,7 @@ const TEMP_WORK_DIR = path.resolve(
   "npm-postinstall-temp-work"
 ); // Dir for temporary package building
 const GITHUB_REF = process.env.GITHUB_REF; // e.g., refs/tags/v1.2.3
+const RELEASE_TAG = process.env.RELEASE_TAG; // e.g., v1.2.3 - directly from workflow
 const NPM_TOKEN = process.env.NODE_AUTH_TOKEN;
 const NPM_PROVENANCE = process.env.NPM_CONFIG_PROVENANCE === "true";
 // --- End Configuration ---
@@ -27,9 +28,18 @@ function error(message) {
 }
 
 function getVersionFromTag(ref) {
+  // First try to use RELEASE_TAG if available
+  if (RELEASE_TAG) {
+    if (RELEASE_TAG.startsWith("v")) {
+      return RELEASE_TAG.substring(1); // Remove 'v' prefix
+    }
+    return RELEASE_TAG; // Use as-is if no 'v' prefix
+  }
+
+  // Fall back to GITHUB_REF
   if (!ref || !ref.startsWith("refs/tags/v")) {
     error(
-      `Invalid or missing GITHUB_REF tag: ${ref}. Must start with 'refs/tags/v'.`
+      `Invalid or missing GITHUB_REF tag: ${ref}. Must start with 'refs/tags/v' or set RELEASE_TAG env variable.`
     );
   }
   return ref.substring("refs/tags/v".length);


### PR DESCRIPTION
- Introduced `RELEASE_TAG` environment variable to allow direct version extraction, enhancing flexibility in version handling.
- Updated `getVersionFromTag` function to prioritize `RELEASE_TAG` over `GITHUB_REF`, improving error messaging for missing tags.

Signed-off-by: Alessandro De Blasis <alex@deblasis.net>