### PR TITLE
fix(workflow): update authentication token for winget repo in release…

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -365,9 +365,9 @@ jobs:
 
           BRANCH_NAME="pull-watch-${APP_VERSION_NO_V}"
           echo "Pushing manifest updates commit to branch ${BRANCH_NAME} in ${WINGET_REPO_OWNER}/${WINGET_REPO_NAME}..."
-          # Use the GITHUB_TOKEN provided by the workflow runner for authentication
+          # Use the WINGET_GITHUB_TOKEN provided by the secrets for authentication to the winget repo
           # Ensure the token has permissions to write to the fork.
-          git push https://${COMMIT_AUTHOR_NAME}:${{ secrets.GITHUB_TOKEN }}@github.com/${WINGET_REPO_OWNER}/${WINGET_REPO_NAME}.git HEAD:"${BRANCH_NAME}" --force-with-lease
+          git push https://${COMMIT_AUTHOR_NAME}:${{ secrets.WINGET_GITHUB_TOKEN }}@github.com/${WINGET_REPO_OWNER}/${WINGET_REPO_NAME}.git HEAD:"${BRANCH_NAME}" --force-with-lease
 
           echo "Successfully pushed changes to winget fork branch ${BRANCH_NAME}."
           cd ..


### PR DESCRIPTION
…orkflow

- Changed the authentication token from `GITHUB_TOKEN` to `WINGET_GITHUB_TOKEN` for pushing manifest updates to the winget repository. This ensures proper access permissions for the workflow.